### PR TITLE
UX: add custom New Message button to /my/messages

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -9,4 +9,20 @@
   body:not(.staff) .composer-fields .user-selector {
     display: none !important;
   }
+
+  // hide user messages page default PM button, unless staff
+  body:not(.staff) {
+    .user-main {
+      .new-private-message {
+        display: none;
+      }
+    }
+  }
+
+  // hide user messages page custom PM button for staff
+  body.staff {
+    .custom-new-private-message {
+      display: none;
+    }
+  }
 }

--- a/javascripts/discourse/connectors/user-messages-controls-bottom/custom-new-message-button.hbs
+++ b/javascripts/discourse/connectors/user-messages-controls-bottom/custom-new-message-button.hbs
@@ -1,0 +1,10 @@
+{{#if (theme-setting "pm_recipients")}}
+  {{#if this.showNewPM}}
+    <DButton
+      @class="btn-primary custom-new-private-message"
+      @action={{this.customCreateNewMessage}}
+      @icon="envelope"
+      @label="user.new_private_message"
+    />
+  {{/if}}
+{{/if}}

--- a/javascripts/discourse/connectors/user-messages-controls-bottom/custom-new-message-button.js
+++ b/javascripts/discourse/connectors/user-messages-controls-bottom/custom-new-message-button.js
@@ -1,0 +1,20 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+import { action } from "@ember/object";
+import Composer from "discourse/models/composer";
+
+export default class CustomNewMessageButton extends Component {
+  @service composer;
+  showNewPM = this.args.outletArgs.showNewPM;
+
+  @action
+  customCreateNewMessage() {
+    const recipients = settings.pm_recipients;
+    this.composer.open({
+      action: Composer.PRIVATE_MESSAGE,
+      recipients,
+      archetypeId: "private_message",
+      draftKey: Composer.NEW_PRIVATE_MESSAGE_KEY,
+    });
+  }
+}

--- a/javascripts/discourse/initializers/initialize-composer-toggle-hijack.js
+++ b/javascripts/discourse/initializers/initialize-composer-toggle-hijack.js
@@ -21,6 +21,7 @@ export default {
     if (settings.hijack_pm_toggle) {
       withPluginApi("0.8.14", (api) => {
         api.modifyClass("component:composer-actions", {
+          pluginId: "new-topic-dropdown",
           replyAsPrivateMessageSelected(options) {
             let usernames;
             let _postSnapshot;
@@ -67,6 +68,8 @@ export default {
     if (settings.composer_pm_toggle) {
       withPluginApi("0.8.14", (api) => {
         api.modifyClass("component:composer-actions", {
+          pluginId: "new-topic-dropdown",
+
           @discourseComputed("seq")
           content() {
             let items = [];


### PR DESCRIPTION
This adds a custom `New Message` button to `/my/messages` that prefills the set recipient. 

This feature is for a site where a new PMs from non-staff users are directed to a single recipient.