### PR TITLE
FIX: pluginId needs to be unique

### DIFF
--- a/javascripts/discourse/initializers/initialize-composer-toggle-hijack.js
+++ b/javascripts/discourse/initializers/initialize-composer-toggle-hijack.js
@@ -68,7 +68,7 @@ export default {
     if (settings.composer_pm_toggle) {
       withPluginApi("0.8.14", (api) => {
         api.modifyClass("component:composer-actions", {
-          pluginId: "new-topic-dropdown",
+          pluginId: "new-topic-dropdown-action",
 
           @discourseComputed("seq")
           content() {


### PR DESCRIPTION
This pluginId needs to be unique, I reused the same name in `a038f9f` and it broke this! 